### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,8 @@
+---
 version: 2
 updates:
 - package-ecosystem: docker
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: library/golang
-    versions:
-    - 1.15.7
-    - 1.16.0
-    - 1.16.1
-    - 1.16.2


### PR DESCRIPTION
Fixes #42 
1:1 warning missing document start "---" (document-start)
4:14 error string value is redundantly quoted with double quotes (quoted-strings)